### PR TITLE
Migrate to Console API tracking-scenarios v2 (close #74)

### DIFF
--- a/src/components/Modals/ConsoleSync.tsx
+++ b/src/components/Modals/ConsoleSync.tsx
@@ -193,7 +193,7 @@ export const ConsoleSync: FunctionComponent<ConsoleSyncOptions> = ({
           Promise.all(
             targetOrgs.flatMap((org) => [
               apiFetch(
-                `organizations/${org.id}/tracking-scenarios/v1`,
+                `organizations/${org.id}/tracking-scenarios/v2`,
                 authentication,
               ).then((results) =>
                 specFromTrackingScenarios(org.name, results.data),

--- a/src/ts/util.ts
+++ b/src/ts/util.ts
@@ -53,6 +53,16 @@ const isSnowplow = (request: Request): boolean => {
   return false;
 };
 
+type ScenarioTrigger = {
+  description: string
+  appIds?: string[],
+  url?: string,
+  variantUrls?: {
+    original: string,
+    thumbnail: string,
+  },
+}
+
 type TrackingScenario = {
   id: string;
   message: string;
@@ -65,7 +75,7 @@ type TrackingScenario = {
   dataProductId?: string;
   description?: string;
   appIds?: string[];
-  triggers?: string[];
+  triggers?: ScenarioTrigger[];
   event?: {
     source: string;
     schema?: Schema;
@@ -89,7 +99,7 @@ const specFromTrackingScenario = (
 ): TestSuiteSpec => {
   const triggers = scenario.triggers || [];
   const triggerText = triggers.length
-    ? "Should trigger when:\n- " + triggers.join("\n- ")
+    ? "Should trigger when:\n- " + triggers.map(trigger => trigger.description).join("\n- ")
     : "";
 
   let uncheckableWarning = "";


### PR DESCRIPTION
Migrating to Tracking Scenarios v2 API, the only thing that seems to need changing in the extension code is the `triggers` that we show.

_This is my first contribution so if there is anything else I need to do let me know!_