### PR TITLE
Only render parsed JSON string values if they are complex

### DIFF
--- a/src/components/Debugger/Beacon.tsx
+++ b/src/components/Debugger/Beacon.tsx
@@ -326,6 +326,8 @@ const BeaconValue: FunctionComponent<BeaconValueAttrs> = ({
       case "string":
         try {
           const json = JSON.parse(obj);
+          if (typeof json !== "object")
+            throw Error("Simple JSON value can be displayed normally");
           return (
             <BeaconValue resolver={resolver} obj={json} setModal={setModal} />
           );


### PR DESCRIPTION
To support the case where complex values are tracked as JSON strings, when rendering SDJ values if the value is a string, we attempt to parse it as JSON, and, if successful, render that object (still labelled with the type "string") as the parsed representation; this allows you to more easily see that the encoded data is what you're expecting.

This makes sense for complex values like Arrays and Objects, but produces unexpected behaviour for scalar values such as Numbers, where it is a common pattern to store numeric values beyond the `Number.MIN_SAFE_INTEGER` - `Number.MAX_SAFE_INTEGER` range as strings; the strings parse as JSON correctly, but the resulting `Number` is truncated to be representable with the bitspace JS has available to it.

E.g. `JSON.parse("-4135769237694892496") ===  -4135769237694892500`

This results in the `Data` tab showing a different result to the actual data sent, as seen in the `JSON` tab.

We fix this by only moving forward with the parsed JSON object if it's a complex type, otherwise bailing out to keep using the string value representation.